### PR TITLE
Fix bullet point display in Styles UI

### DIFF
--- a/src/components/sessions/StylesEditor.tsx
+++ b/src/components/sessions/StylesEditor.tsx
@@ -738,7 +738,7 @@ export const StylesEditor = memo(function StylesEditor({
                     }}
                     className="w-full px-3 py-1.5 text-sm border border-border rounded-md bg-background"
                   >
-                    <option value={'\uF0B7'}>{'\uF0B7'} Bullet (Calibri)</option>
+                    <option value={'\uF0B7'}>• Bullet (Calibri)</option>
                     <option value="○">○ Open Circle</option>
                     <option value="■">■ Closed Square</option>
                     <option value="□">□ Open Square</option>
@@ -766,7 +766,7 @@ export const StylesEditor = memo(function StylesEditor({
                     }}
                     className="w-full px-3 py-1.5 text-sm border border-border rounded-md bg-background"
                   >
-                    <option value={'\uF0B7'}>{'\uF0B7'} Bullet (Calibri)</option>
+                    <option value={'\uF0B7'}>• Bullet (Calibri)</option>
                     <option value="○">○ Open Circle</option>
                     <option value="■">■ Closed Square</option>
                     <option value="□">□ Open Square</option>
@@ -794,7 +794,7 @@ export const StylesEditor = memo(function StylesEditor({
                     }}
                     className="w-full px-3 py-1.5 text-sm border border-border rounded-md bg-background"
                   >
-                    <option value={'\uF0B7'}>{'\uF0B7'} Bullet (Calibri)</option>
+                    <option value={'\uF0B7'}>• Bullet (Calibri)</option>
                     <option value="○">○ Open Circle</option>
                     <option value="■">■ Closed Square</option>
                     <option value="□">□ Open Square</option>
@@ -814,7 +814,7 @@ export const StylesEditor = memo(function StylesEditor({
                   {listBulletSettings.indentationLevels.map((level) => (
                     <div key={level.level} className="text-center">
                       <div className="font-medium text-xs text-muted-foreground">L{level.level}</div>
-                      <div className="text-lg">{level.bulletChar}</div>
+                      <div className="text-lg">{level.bulletChar === '\uF0B7' ? '•' : level.bulletChar}</div>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
- Changed dropdown display from \uF0B7 (renders as ?) to • (U+2022)
- Updated bullet preview to show • when bulletChar is \uF0B7
- Values sent to docxmlater remain unchanged (\uF0B7 is correct)
- Fixes question mark display issue in Styles UI