### PR TITLE
Fix TypeScript errors in document processing

### DIFF
--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -823,6 +823,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         // Text Formatting Options
         removeWhitespace?: boolean;
         removeParagraphLines?: boolean;
+        preserveBlankLinesAfterHeader2Tables?: boolean;
         removeItalics?: boolean;
 
         // Content Structure Options


### PR DESCRIPTION
…essor

- Added preserveBlankLinesAfterHeader2Tables to SessionContext type definition
- Updated WordDocumentProcessor.removeExtraParagraphLines to accept preserveBlankLinesAfterHeader2Tables parameter
- Updated WordDocumentProcessor.applyCustomStylesFromUI to accept preserveBlankLinesAfterHeader2Tables parameter
- Updated all method calls to pass the required parameters

Resolves TypeScript errors:
- src/contexts/SessionContext.tsx:908 (preserveBlankLinesAfterHeader2Tables property)
- src/services/document/WordDocumentProcessor.ts:1346 (this.options access)
- src/services/document/WordDocumentProcessor.ts:1645 (this.options access)