### PR TITLE
Debug hyperlink standardizing function error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Implemented a complete formatting standardization system that ensures all hyperl
 
 #### Hyperlink Formatting Standardization
 
-**Current Implementation (v1.0.45):**
+**Current Implementation (v1.0.47 - BUG FIX):**
 
 - Font: **Verdana 12pt** (updated from Calibri 11pt)
 - Color: **#0000FF** (bright blue, updated from #0563C1)
@@ -35,6 +35,15 @@ Implemented a complete formatting standardization system that ensures all hyperl
 - Matches document body text standards
 - Better readability and professional appearance
 - Consistent with organizational style guidelines
+
+**IMPORTANT BUG FIX (v1.0.47):**
+- **Issue**: Hyperlinks were rendering as 24pt instead of 12pt
+- **Root Cause**: Incorrect assumption about docxmlater's `setFormatting()` method
+  - We passed `size: 24` thinking it expected half-points (12pt = 24 half-points)
+  - But docxmlater expects `size` in **points** and converts internally (size * 2)
+  - Result: 24 points → 48 half-points → **24pt font** (wrong!)
+- **Fix**: Changed `size: 24` to `size: 12` (docxmlater handles conversion)
+- **Technical Note**: Unlike direct XML manipulation, docxmlater's API uses user-friendly point values
 
 #### List Prefix Formatting Standardization (NEW)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "documentation-hub",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "A modern document processing and session management desktop application",
   "main": "dist/electron/main.js",
   "scripts": {

--- a/src/services/document/WordDocumentProcessor.ts
+++ b/src/services/document/WordDocumentProcessor.ts
@@ -1714,7 +1714,7 @@ export class WordDocumentProcessor {
           // - Italic: false
           hyperlink.setFormatting({
             font: 'Verdana',
-            size: 24, // 12pt = 24 half-points
+            size: 12, // 12pt (docxmlater converts to 24 half-points internally)
             color: '0000FF', // Blue (hex without #)
             underline: 'single',
             bold: false,


### PR DESCRIPTION
Fixed critical bug in hyperlink standardization where hyperlinks were appearing as 24pt instead of the intended 12pt.

Root Cause:
- docxmlater's setFormatting() expects size parameter in POINTS
- Framework internally converts: points * 2 = half-points for DOCX XML
- Previous code incorrectly passed size: 24 (thinking it was half-points)
- Result: 24 points → 48 half-points → 24pt font (WRONG)

Fix:
- Changed size: 24 to size: 12 in setFormatting() call
- docxmlater now correctly converts: 12 * 2 = 24 half-points = 12pt
- Updated documentation in CLAUDE.md to explain the issue
- Bumped version to 1.0.47

Technical Details:
- File: src/services/document/WordDocumentProcessor.ts:1717
- Method: standardizeHyperlinkFormatting()
- API Note: Unlike direct XML manipulation (which uses half-points), docxmlater's API accepts user-friendly point values

References:
- docxmlater Run class: converts size * 2 during XML generation
- DOCX XML spec: font sizes stored as half-points